### PR TITLE
fix(trash.py): Initial commit trying to fix IsDirectoryError

### DIFF
--- a/gitfourchette/trash.py
+++ b/gitfourchette/trash.py
@@ -61,6 +61,8 @@ class Trash:
             if os.path.isfile(fullPath):
                 logger.debug(f"Deleting trash file {fullPath}")
                 os.unlink(fullPath)
+            elif os.path.isdir(fullPath):
+                os.unlink(fullPath)
 
     def newFile(self, workdir: str, ext: str = "", originalPath: str = "") -> str:
         maxFiles = self.maxFileCount
@@ -95,7 +97,10 @@ class Trash:
         if not trashPath:
             return ""
 
-        shutil.copyfile(fullPath, trashPath, follow_symlinks=False)
+        if os.path.isfile(fullPath):
+            shutil.copyfile(fullPath, trashPath, follow_symlinks=False)
+        elif os.path.isdir(fullPath):
+            shutil.copytree(fullPath,trashPath+"/")
         return trashPath
 
     def backupPatch(self, workdir: str, data: bytes, originalPath: str = ""):


### PR DESCRIPTION
Currently when trying to discard files that are directories, the IsDirectoryError is thrown.


![imagen](https://github.com/user-attachments/assets/bfad974e-9c8f-4197-9d1e-a65ac7328583)

The current commit fixes the error and creates correctly the backup files, but I haven't been able to locate where the removing is performed in all the codebase, so that part is still missing.