### PR TITLE
README: Link to the documentation source

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ Learn more on GitFourchette’s homepage at [gitfourchette.org](https://gitfourc
 
 ## Documentation
 
-- [GitFourchette User’s Guide](https://gitfourchette.org/guide)
-- [How to install or run from source](https://gitfourchette.org/install.html)
-- [Limitations](https://gitfourchette.org/limitations.html)
+- [GitFourchette's website](https://gitfourchette.org) ([source code](https://github.com/jorio/gitfourchette.org))
+  - [How to install or run from source](https://gitfourchette.org/install.html)
+  - [User’s Guide](https://gitfourchette.org/guide)
+  - [Limitations](https://gitfourchette.org/limitations.html)
 - [Changelog](CHANGELOG.md)
 - [Localization guide](gitfourchette/assets/lang/README.md)
 


### PR DESCRIPTION
It was not immediately obvious to me where GitFourchette website's source code has kept, and how to contribute to it. This PR adds an explicit link to the documentation website and its source code, and places the links to the three main sections of the website as a sublist, to distinguish them from the documentation pages hosted in markdown files in this repository.