### PR TITLE
Options for commit hash display

### DIFF
--- a/gitfourchette/graphview/commitlogdelegate.py
+++ b/gitfourchette/graphview/commitlogdelegate.py
@@ -17,6 +17,7 @@ from gitfourchette.localization import *
 from gitfourchette.porcelain import *
 from gitfourchette.qt import *
 from gitfourchette.repomodel import UC_FAKEID, UC_FAKEREF, RepoModel
+from gitfourchette.settings import CommitHashDisplay
 from gitfourchette.toolbox import *
 
 
@@ -155,10 +156,16 @@ class CommitLogDelegate(QStyledItemDelegate):
             dateWidth = 0
         elif rect.width() <= NARROW_WIDTH[1]:
             authorWidth = int(lerp(authorWidth/2, authorWidth, rect.width(), NARROW_WIDTH[0], NARROW_WIDTH[1]))
-        leftBoundHash = rect.left()
-        leftBoundSummary = leftBoundHash + hcw * settings.prefs.shortHashChars + XSPACING
+        
+        hashLeft = settings.prefs.commitHashDisplay == CommitHashDisplay.Left
+        hashRight = settings.prefs.commitHashDisplay == CommitHashDisplay.Right
+        hashWidth = hcw * settings.prefs.shortHashChars + XSPACING * (3 if hashRight else 1)
+        hashMonospace = hashLeft
+
+        leftBoundSummary = rect.left() + (hashWidth if hashLeft else 0)
         leftBoundDate = rect.width() - dateWidth
-        leftBoundName = leftBoundDate - authorWidth
+        leftBoundName = leftBoundDate - authorWidth - (hashWidth if hashRight else 0)
+        leftBoundHash = rect.left() if hashLeft else leftBoundDate - hashWidth
         rightBound = rect.right()
 
         # Get the info we need about the commit
@@ -190,7 +197,7 @@ class CommitLogDelegate(QStyledItemDelegate):
         else:
             commit = None
             oid = None
-            hashText = "·" * settings.prefs.shortHashChars
+            hashText = "·" * settings.prefs.shortHashChars if hashLeft else ""
             authorText = ""
             dateText = ""
             searchTerm = ""
@@ -230,14 +237,19 @@ class CommitLogDelegate(QStyledItemDelegate):
             SearchBar.highlightNeedle(painter, rect, fullText, needlePos, needleLen)
 
         # ------ Hash
-        charRect = QRect(leftBoundHash, rect.top(), hcw, rect.height())
-        painter.save()
-        if not isSelected:  # use muted color for hash if not selected
-            painter.setPen(palette.color(colorGroup, QPalette.ColorRole.PlaceholderText))
-        for hashChar in hashText:
-            painter.drawText(charRect, Qt.AlignmentFlag.AlignCenter, hashChar)
-            charRect.translate(hcw, 0)
-        painter.restore()
+        if hashLeft or hashRight:
+            width = hcw if hashMonospace else hashWidth
+            charRect = QRect(leftBoundHash, rect.top(), width, rect.height())
+            painter.save()
+            if not isSelected:  # use muted color for hash if not selected
+                painter.setPen(palette.color(colorGroup, QPalette.ColorRole.PlaceholderText))
+            if hashMonospace:
+                for hashChar in hashText:
+                    painter.drawText(charRect, Qt.AlignmentFlag.AlignCenter, hashChar)
+                    charRect.translate(hcw, 0)
+            else:
+                painter.drawText(charRect, Qt.AlignmentFlag.AlignVCenter, hashText)
+            painter.restore()
 
         # ------ Highlight searched hash
         if searchTerm and searchTermLooksLikeHash and commit and str(commit).startswith(searchTerm):

--- a/gitfourchette/settings.py
+++ b/gitfourchette/settings.py
@@ -50,6 +50,12 @@ class GraphRowHeight(enum.IntEnum):
     Spacious = 175
 
 
+class CommitHashDisplay(enum.IntEnum):
+    Left = 0
+    Right = 1
+    Hide = 2
+
+
 class GraphRefBoxWidth(enum.IntEnum):
     IconsOnly = 0
     Standard = 120
@@ -103,6 +109,7 @@ class Prefs(PrefsFile):
     graphRowHeight              : GraphRowHeight        = GraphRowHeight.Relaxed
     refBoxMaxWidth              : GraphRefBoxWidth      = GraphRefBoxWidth.Standard
     authorDisplayStyle          : AuthorDisplayStyle    = AuthorDisplayStyle.FullName
+    commitHashDisplay           : CommitHashDisplay     = CommitHashDisplay.Left
     shortTimeFormat             : str                   = list(SHORT_DATE_PRESETS.values())[0]
     maxCommits                  : int                   = 10000
     authorDiffAsterisk          : bool                  = True

--- a/gitfourchette/trtables.py
+++ b/gitfourchette/trtables.py
@@ -102,7 +102,7 @@ class TrTables:
         from gitfourchette.porcelain import FileMode, NameValidationError
         from gitfourchette.toolbox import toLengthVariants
         from gitfourchette.sidebar.sidebarmodel import SidebarItem
-        from gitfourchette.settings import GraphRowHeight, QtApiNames, GraphRefBoxWidth, RefSort
+        from gitfourchette.settings import CommitHashDisplay, GraphRowHeight, QtApiNames, GraphRefBoxWidth, RefSort
         from gitfourchette.toolbox import PatchPurpose, PathDisplayStyle, AuthorDisplayStyle
 
         NVERule = NameValidationError.Rule
@@ -201,6 +201,12 @@ class TrTables:
                 AuthorDisplayStyle.Initials     : _("Initials"),
                 AuthorDisplayStyle.FullEmail    : _("Full email"),
                 AuthorDisplayStyle.EmailUserName: _("Abbreviated email"),
+            },
+
+            CommitHashDisplay: {
+                CommitHashDisplay.Left          : _p("show commit hashes", "On left"),
+                CommitHashDisplay.Right         : _p("show commit hashes", "On right"),
+                CommitHashDisplay.Hide          : _p("show commit hashes", "Hide"),
             },
 
             GraphRowHeight: {
@@ -349,6 +355,7 @@ class TrTables:
             "shortTimeFormat_help": TrTables._timeFormatTable(),
             "pathDisplayStyle": _("Path display style"),
             "authorDisplayStyle": _("Author display style"),
+            "commitHashDisplay": _("Show commit hashes"),
             "maxRecentRepos": _("Remember up to # recent repositories"),
             "showStatusBar": _("Show status bar"),
             "showToolBar": _("Show toolbar"),


### PR DESCRIPTION
Adds an option to show hashes on the right, or to hide them entirely:

<img height="400" alt="image" src="https://github.com/user-attachments/assets/14d4c080-dac7-46bc-b769-1d938f4dc328" />
