### PR TITLE
Install Return shortcut on dialogs

### DIFF
--- a/gitfourchette/forms/clonedialog.py
+++ b/gitfourchette/forms/clonedialog.py
@@ -107,6 +107,8 @@ class CloneDialog(QDialog):
             self.ui.recurseSubmodulesCheckBox.setEnabled(False)
             self.ui.recurseSubmodulesCheckBox.setText("Recursing into submodules requires pygit2 1.15.1+")
 
+        installDialogReturnShortcut(self)
+
     def validateUrl(self, url):
         if not url:
             return _("Please fill in this field.")

--- a/gitfourchette/forms/prefsdialog.py
+++ b/gitfourchette/forms/prefsdialog.py
@@ -107,6 +107,7 @@ class PrefsDialog(QDialog):
             PrefsDialog.lastCategory = self.stackedWidget.currentIndex()
 
         self.setModal(True)
+        installDialogReturnShortcut(self)
 
     def _fillControls(self, focusOn):
         category = "general"

--- a/gitfourchette/tasks/repotask.py
+++ b/gitfourchette/tasks/repotask.py
@@ -466,6 +466,7 @@ class RepoTask(QObject):
             nonlocal didReject
             didReject = True
 
+        installDialogReturnShortcut(dialog)
         dialog.rejected.connect(onReject)
         dialog.finished.connect(self.uiReady)
         if proceedSignal:

--- a/gitfourchette/toolbox/__init__.py
+++ b/gitfourchette/toolbox/__init__.py
@@ -55,6 +55,7 @@ from .qtutils import (
     tweakWidgetFont,
     formatWidgetText,
     formatWidgetTooltip,
+    installDialogReturnShortcut,
     itemViewVisibleRowRange,
     isDarkTheme,
     mutedTextColorHex,

--- a/gitfourchette/toolbox/qtutils.py
+++ b/gitfourchette/toolbox/qtutils.py
@@ -402,6 +402,18 @@ def setTabOrder(*args: QWidget):
         QWidget.setTabOrder(widget1, widget2)
 
 
+def installDialogReturnShortcut(dialog: QDialog):
+    buttonBox = dialog.findChild(QDialogButtonBox)
+    if not buttonBox:
+        return
+
+    okButton = buttonBox.button(QDialogButtonBox.StandardButton.Ok)
+    if not okButton:
+        return
+
+    okButton.setShortcut(Qt.Key.Key_Return)
+
+
 class DocumentLinks:
     """
     Bundle of ad-hoc links bound to callback functions.

--- a/gitfourchette/toolbox/qtutils.py
+++ b/gitfourchette/toolbox/qtutils.py
@@ -411,9 +411,7 @@ def installDialogReturnShortcut(dialog: QDialog):
     if not okButton:
         return
 
-    for sequence in ("Return", "Ctrl+Return"):
-        shortcut = QShortcut(sequence, okButton)
-        shortcut.activated.connect(okButton.animateClick)
+    makeWidgetShortcut(okButton, okButton.click, "Ctrl+Return", "Return")
 
 
 class DocumentLinks:

--- a/gitfourchette/toolbox/qtutils.py
+++ b/gitfourchette/toolbox/qtutils.py
@@ -411,7 +411,9 @@ def installDialogReturnShortcut(dialog: QDialog):
     if not okButton:
         return
 
-    okButton.setShortcut(Qt.Key.Key_Return)
+    for sequence in ("Return", "Ctrl+Return"):
+        shorcut = QShortcut(sequence, okButton)
+        shorcut.activated.connect(okButton.animateClick)
 
 
 class DocumentLinks:

--- a/gitfourchette/toolbox/qtutils.py
+++ b/gitfourchette/toolbox/qtutils.py
@@ -412,8 +412,8 @@ def installDialogReturnShortcut(dialog: QDialog):
         return
 
     for sequence in ("Return", "Ctrl+Return"):
-        shorcut = QShortcut(sequence, okButton)
-        shorcut.activated.connect(okButton.animateClick)
+        shortcut = QShortcut(sequence, okButton)
+        shortcut.activated.connect(okButton.animateClick)
 
 
 class DocumentLinks:


### PR DESCRIPTION
Second take on #66. Apparently Return is supposed to work on these dialogues, but it doesn't quite work on GNOME. This makes it work everywhere.

I added both Return and Ctrl+Return. It seems like Qt cleverly figures out that Return in a multi-line text box (such as a long commit message) should not activate a shortcut on the parent widget, and in this case, it's nice for Ctrl+Return to also work.

@jorio, do you know if we can test shortcuts?