### PR TITLE
Count UTF-16 code units when highlighting code

### DIFF
--- a/gitfourchette/codeview/codehighlighter.py
+++ b/gitfourchette/codeview/codehighlighter.py
@@ -9,7 +9,7 @@ import logging
 from gitfourchette import colors
 from gitfourchette.syntax import ColorScheme, LexJob
 from gitfourchette.qt import *
-from gitfourchette.toolbox import benchmark, CallbackAccumulator
+from gitfourchette.toolbox import benchmark, CallbackAccumulator, utf16Length
 
 logger = logging.getLogger(__name__)
 
@@ -91,6 +91,11 @@ class CodeHighlighter(QSyntaxHighlighter):
     def setColorScheme(self, scheme: ColorScheme):
         self.scheme = scheme
         scheme.primeHighContrastVersion()
+
+    def setFormat(self, start: int, size: int, charFormat: QTextCharFormat):
+        text = self.currentBlock().text()
+        # Workaround: setFormat's index counts UTF-16 code units, not characters.
+        super().setFormat(utf16Length(text[:start]), utf16Length(text[start:start + size]), charFormat)
 
     @CallbackAccumulator.deferredMethod
     @benchmark

--- a/gitfourchette/diffview/diffdocument.py
+++ b/gitfourchette/diffview/diffdocument.py
@@ -306,9 +306,11 @@ class DiffDocument:
             cf = style.delCF2 if ld.diffLine.origin == '-' else style.addCF2
             offset = ld.cursorStart
 
+            line = ld.diffLine.content
             for x1, x2 in _invertMatchingBlocks(blocks, useA=aheadOfDoppelganger):
-                cursor.setPosition(offset + x1, QTextCursor.MoveMode.MoveAnchor)
-                cursor.setPosition(offset + x2, QTextCursor.MoveMode.KeepAnchor)
+                # Workaround: setPosition's index counts UTF-16 code units, not characters.
+                cursor.setPosition(offset + utf16Length(line[:x1]), QTextCursor.MoveMode.MoveAnchor)
+                cursor.setPosition(offset + utf16Length(line[:x2]), QTextCursor.MoveMode.KeepAnchor)
                 cursor.setCharFormat(cf)
 
         assert not doppelgangerBlocksQueue, "should've consumed all doppelganger matching blocks!"

--- a/gitfourchette/diffview/diffhighlighter.py
+++ b/gitfourchette/diffview/diffhighlighter.py
@@ -10,6 +10,7 @@ from gitfourchette.appconsts import *
 from gitfourchette.codeview.codehighlighter import CodeHighlighter
 from gitfourchette.diffview.diffdocument import DiffDocument, LineData
 from gitfourchette.syntax import LexJob, ColorScheme
+from gitfourchette.toolbox import utf16Length
 
 logger = logging.getLogger(__name__)
 

--- a/gitfourchette/toolbox/__init__.py
+++ b/gitfourchette/toolbox/__init__.py
@@ -93,6 +93,7 @@ from .textutils import (
     withUniqueSuffix,
     englishTitleCase,
     naturalSort,
+    utf16Length,
 )
 from .urltooltip import UrlToolTip
 from .validatormultiplexer import ValidatorMultiplexer

--- a/gitfourchette/toolbox/textutils.py
+++ b/gitfourchette/toolbox/textutils.py
@@ -244,7 +244,4 @@ def naturalSort(text: str):
 
 
 def utf16Length(text: str):
-    length = 0
-    for c in text:
-        length += 1 + (c > '\uffff')
-    return length
+    return len(text.encode('utf-16LE')) // 2

--- a/gitfourchette/toolbox/textutils.py
+++ b/gitfourchette/toolbox/textutils.py
@@ -241,3 +241,10 @@ def naturalSort(text: str):
     text = text.casefold()
     parts = _naturalSortSplit.split(text)
     return [int(part) if part.isdigit() else part for part in parts]
+
+
+def utf16Length(text: str):
+    length = 0
+    for c in text:
+        length += 1 + (c > '\uffff')
+    return length


### PR DESCRIPTION
Fixes #58. I do wonder if this could be considered a PyQt6 bug... But the documentation for [setPosition](https://doc.qt.io/qt-6/qtextcursor.html#setPosition) is arguably explicit about this behavior:

> Note: The "characters" in this case refer to the string of [QChar](https://doc.qt.io/qt-6/qchar.html) objects, i.e. 16-bit Unicode characters, and pos is considered an index into this string. This does not necessarily correspond to individual graphemes in the writing system, as a single grapheme may be represented by multiple Unicode characters, such as in the case of surrogate pairs, linguistic ligatures or diacritics. For a more generic approach to navigating the document, use [movePosition](https://doc.qt.io/qt-6/qtextcursor.html#movePosition)(), which will respect the actual grapheme boundaries in the text.

(We can't use `movePosition` though, because grapheme boundaries are also not what we want to count here.)