### PR TITLE
Show branch name instead of "Reset HEAD to Here"

### DIFF
--- a/gitfourchette/graphview/graphview.py
+++ b/gitfourchette/graphview/graphview.py
@@ -145,7 +145,7 @@ class GraphView(QListView):
 
             checkoutAction = TaskBook.action(self, CheckoutCommit, _("&Check Out…"), taskArgs=oid)
             checkoutAction.shortcuts = self.checkoutShortcut.key()
-            resetLabel = _("&Reset {0} to Here…", lquo(repoModel.homeBranch) if repoMode.homeBranch else "HEAD")
+            resetLabel = _("&Reset {0} to Here…", lquo(repoModel.homeBranch) if repoModel.homeBranch else "HEAD")
 
             actions = [
                 *mergeActions,

--- a/gitfourchette/graphview/graphview.py
+++ b/gitfourchette/graphview/graphview.py
@@ -145,6 +145,7 @@ class GraphView(QListView):
 
             checkoutAction = TaskBook.action(self, CheckoutCommit, _("&Check Out…"), taskArgs=oid)
             checkoutAction.shortcuts = self.checkoutShortcut.key()
+            resetLabel = _("&Reset {0} to Here…", lquo(repoModel.homeBranch) if repoMode.homeBranch else "HEAD")
 
             actions = [
                 *mergeActions,
@@ -153,7 +154,7 @@ class GraphView(QListView):
                 TaskBook.action(self, NewTag, _("&Tag This Commit…"), taskArgs=oid),
                 ActionDef.SEPARATOR,
                 checkoutAction,
-                TaskBook.action(self, ResetHead, _("&Reset HEAD to Here…"), taskArgs=oid),
+                TaskBook.action(self, ResetHead, resetLabel, taskArgs=oid),
                 ActionDef.SEPARATOR,
                 TaskBook.action(self, CherrypickCommit, _("Cherry &Pick…"), taskArgs=oid),
                 TaskBook.action(self, RevertCommit, _("Re&vert…"), taskArgs=oid),


### PR DESCRIPTION
When right-clicking in the commit graph, I was confused by "Reset HEAD to Here..." thinking it would detach HEAD, but actually it resets the tip of the current branch. This PR makes that action use the current branch name, which I think is a little clearer — it's just like the double-click (checkout) menu.