### PR TITLE
Replace spaces with dashes when naming branches

### DIFF
--- a/gitfourchette/forms/newbranchdialog.py
+++ b/gitfourchette/forms/newbranchdialog.py
@@ -59,22 +59,12 @@ class NewBranchDialog(QDialog):
 
         self.ui.nameEdit.setFocus()
         self.ui.nameEdit.selectAll()
+        self.ui.nameEdit.setValidator(ReplaceSpacesWithDashes())
         self.preSelectLeaf(self.ui.nameEdit)
 
     @property
     def acceptButton(self):
         return self.ui.buttonBox.button(QDialogButtonBox.StandardButton.Ok)
-
-    def branchTextEdited(self, text: str):
-        """
-        Allow using spacebar to input valid branch names
-        """
-        if ' ' in text:
-            cursor_pos = self.ui.nameEdit.cursorPosition()
-            newText = text.replace(' ', '-')
-            self.ui.nameEdit.setText(newText)
-            # Restore the cursor position so it doesn't jump to the end
-            self.ui.nameEdit.setCursorPosition(cursor_pos)
 
     @staticmethod
     def preSelectLeaf(nameEdit: QLineEdit):

--- a/gitfourchette/forms/ui_newbranchdialog.py
+++ b/gitfourchette/forms/ui_newbranchdialog.py
@@ -67,7 +67,6 @@ class Ui_NewBranchDialog(object):
         self.nameLabel.setBuddy(self.nameEdit)
 
         self.retranslateUi(NewBranchDialog)
-        self.nameEdit.textEdited.connect(NewBranchDialog.branchTextEdited) # type: ignore
         self.buttonBox.rejected.connect(NewBranchDialog.reject) # type: ignore
         self.buttonBox.accepted.connect(NewBranchDialog.accept) # type: ignore
         self.upstreamCheckBox.toggled['bool'].connect(self.upstreamComboBox.setEnabled) # type: ignore

--- a/gitfourchette/tasks/branchtasks.py
+++ b/gitfourchette/tasks/branchtasks.py
@@ -85,17 +85,6 @@ class RenameBranch(RepoTask):
 
         nameTaken = _("This name is already taken by another local branch.")
 
-        def branchTextEdited(text: str):
-            """
-            Allow using spacebar to input valid branch names
-            """
-            if ' ' in text:
-                cursorPosition = dlg.lineEdit.cursorPosition()
-                newText = text.replace(' ', '-')
-                dlg.lineEdit.setText(newText)
-                # Restore the cursor position so it doesn't jump to the end
-                dlg.lineEdit.setCursorPosition(cursorPosition)
-
         dlg = TextInputDialog(
             self.parentWidget(),
             _("Rename local branch"),
@@ -103,7 +92,7 @@ class RenameBranch(RepoTask):
             subtitle=_("Current name: {0}", oldBranchName))
         dlg.setText(oldBranchName)
         dlg.setValidator(lambda name: nameValidationMessage(name, forbiddenBranchNames, nameTaken))
-        dlg.lineEdit.textEdited.connect(branchTextEdited)
+        dlg.lineEdit.setValidator(ReplaceSpacesWithDashes())
         dlg.okButton.setText(_("Rename"))
 
         # Pre-select leaf name (e.g. in "folder/leaf" select only "leaf")
@@ -162,17 +151,6 @@ class RenameBranchFolder(RepoTask):
                       "Folder {name} contains {n} branches.",
                       len(folderBranches), name=lquoe(oldFolderName))
 
-        def branchTextEdited(text: str):
-            """
-            Allow using spacebar to input valid branch names
-            """
-            if ' ' in text:
-                cursorPosition = dlg.lineEdit.cursorPosition()
-                newText = text.replace(' ', '-')
-                dlg.lineEdit.setText(newText)
-                # Restore the cursor position so it doesn't jump to the end
-                dlg.lineEdit.setCursorPosition(cursorPosition)
-
         dlg = TextInputDialog(
             self.parentWidget(),
             _("Rename branch folder"),
@@ -182,7 +160,7 @@ class RenameBranchFolder(RepoTask):
         dlg.setValidator(validate)
         dlg.okButton.setText(_("Rename"))
         dlg.lineEdit.setPlaceholderText(_("Leave blank to move the branches to the root folder."))
-        dlg.lineEdit.textEdited.connect(branchTextEdited)
+        dlg.lineEdit.setValidator(ReplaceSpacesWithDashes())
 
         yield from self.flowDialog(dlg)
         dlg.deleteLater()

--- a/gitfourchette/toolbox/__init__.py
+++ b/gitfourchette/toolbox/__init__.py
@@ -98,3 +98,4 @@ from .textutils import (
 )
 from .urltooltip import UrlToolTip
 from .validatormultiplexer import ValidatorMultiplexer
+from .validators import ReplaceSpacesWithDashes

--- a/gitfourchette/toolbox/validators.py
+++ b/gitfourchette/toolbox/validators.py
@@ -1,0 +1,13 @@
+# -----------------------------------------------------------------------------
+# Copyright (C) 2025 Iliyas Jorio.
+# This file is part of GitFourchette, distributed under the GNU GPL v3.
+# For full terms, see the included LICENSE file.
+# -----------------------------------------------------------------------------
+
+from gitfourchette.qt import QValidator
+
+
+class ReplaceSpacesWithDashes(QValidator):
+    def validate(self, text: str, pos: int) -> tuple[QValidator.State, str, int]:
+        text = text.replace(" ", "-")
+        return QValidator.State.Acceptable, text, pos

--- a/test/test_tasks_branch.py
+++ b/test/test_tasks_branch.py
@@ -73,8 +73,7 @@ def testNewBranchNaming(tempDir, mainWindow):
     dlg: NewBranchDialog = findQDialog(rw, "new branch")
     nameEdit = dlg.ui.nameEdit
 
-    nameEdit.setText("hellobranch")
-    nameEdit.textEdited.emit("hello branch")
+    nameEdit.setText("hello branch")
 
     assert nameEdit.text() == "hello-branch"
 
@@ -206,7 +205,7 @@ def testRenameBranch(tempDir, mainWindow, method):
         "nope.lock", "nope/", "nope.",
         "nope/.nope", "nope//nope", "nope@{nope", "no..pe",
         ".nope", "/nope",
-        "no pe", "no~pe", "no^pe", "no:pe", "no[pe", "no?pe", "no*pe", "no\\pe",
+        "no~pe", "no^pe", "no:pe", "no[pe", "no?pe", "no*pe", "no\\pe",
         "nul", "nope/nul", "nul/nope", "lpt3", "com2",
     ]
     fixableNames = [
@@ -338,13 +337,20 @@ def testRenameBranchFolder(tempDir, mainWindow, method, newName):
         "nope.lock", "nope/", "nope.",
         "nope/.nope", "nope//nope", "nope@{nope", "no..pe",
         ".nope", "/nope",
-        "no pe", "no~pe", "no^pe", "no:pe", "no[pe", "no?pe", "no*pe", "no\\pe",
+        "no~pe", "no^pe", "no:pe", "no[pe", "no?pe", "no*pe", "no\\pe",
         "nul", "nope/nul", "nul/nope", "lpt3", "com2",
+    ]
+    fixableNames = [
+        # Illegal patterns that can be automatically fixed by the input field
+        "no pe",
     ]
     for bad in badNames:
         nameEdit.setText(bad)
         assert not okButton.isEnabled(), f"name shouldn't pass validation: {bad}"
         print(bad, "-->", nameEdit.actions()[0].toolTip())
+    for fixable in fixableNames:
+        nameEdit.setText(fixable)
+        assert okButton.isEnabled(), f"name should pass validation: {fixable}"
 
     nameEdit.setText(newName)
     assert okButton.isEnabled()


### PR DESCRIPTION
This is a small quality-of-life change to make using the `New Branch` and `Rename Branch` menus feel more natural. Since spaces in branch names are invalid, this will interactively replace spaces with dashes while typing, ensuring that the input remains valid.