### PR TITLE
feat(Sidebar): Add filter input for branches, tags, and stashes

### DIFF
--- a/gitfourchette/repowidget.py
+++ b/gitfourchette/repowidget.py
@@ -283,6 +283,31 @@ class RepoWidget(QWidget):
     def _makeSidebarContainer(self):
         sidebar = Sidebar(self)
 
+        from gitfourchette.sidebar.sidebarfilter import SidebarFilter
+        sidebarFilter = SidebarFilter(self)
+        sidebarFilter.textChanged.connect(sidebar.model().setFilterText)
+
+        def onFilterTextChanged(text: str):
+            if text.strip():
+                sidebar.expandAll()
+            else:
+                sidebar.restoreExpandedItems()
+
+        sidebarFilter.textChanged.connect(onFilterTextChanged)
+
+        def focusFilter():
+            sidebarFilter.setFocus()
+
+        makeWidgetShortcut(sidebar, focusFilter, "/")
+
+        def clearFilter():
+            if sidebarFilter.filterText:
+                sidebarFilter.clear()
+            else:
+                sidebar.setFocus()
+
+        makeWidgetShortcut(sidebarFilter, clearFilter, "Escape")
+
         banner = Banner(self, orientation=Qt.Orientation.Vertical)
         banner.setProperty("class", "merge")
         banner.setSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Preferred)
@@ -291,10 +316,12 @@ class RepoWidget(QWidget):
         layout = QVBoxLayout(container)
         layout.setContentsMargins(QMargins())
         layout.setSpacing(0)
+        layout.addWidget(sidebarFilter)
         layout.addWidget(sidebar)
         layout.addWidget(banner)
 
         self.sidebar = sidebar
+        self.sidebarFilter = sidebarFilter
         self.mergeBanner = banner
 
         return container

--- a/gitfourchette/sidebar/sidebar.py
+++ b/gitfourchette/sidebar/sidebar.py
@@ -876,14 +876,14 @@ class Sidebar(QTreeView):
         """ Unit test helper """
         return len(self.findNodesByKind(kind))
 
-    def indexForRef(self, ref: str) -> QModelIndex | None:
+    def indexForRef(self, ref: str) -> QModelIndex:
         model = self.sidebarModel
         try:
             node = model.nodesByRef[ref]
             sourceIndex = node.createIndex(model)
             return self.model().mapFromSource(sourceIndex)
         except KeyError:
-            return None
+            return QModelIndex()
 
     def selectNode(self, node: SidebarNode) -> QModelIndex:
         sourceIndex = node.createIndex(self.sidebarModel)

--- a/gitfourchette/sidebar/sidebar.py
+++ b/gitfourchette/sidebar/sidebar.py
@@ -110,8 +110,9 @@ class Sidebar(QTreeView):
 
         if index.isValid():
             sourceIndex = self.model().mapToSource(index)
-            node = SidebarNode.fromIndex(sourceIndex)
-            SidebarDelegate.unindentRect(node.kind, vr, self.indentation())
+            if sourceIndex.isValid():
+                node = SidebarNode.fromIndex(sourceIndex)
+                SidebarDelegate.unindentRect(node.kind, vr, self.indentation())
 
         return vr
 
@@ -911,10 +912,12 @@ class Sidebar(QTreeView):
         # Find a visible index that matches any of the candidates
         for ref in refCandidates:
             index = self.indexForRef(ref)
-            if not index:
+            if not index or not index.isValid():
                 continue
             # Don't force-expand any collapsed indexes
             sourceIndex = self.model().mapToSource(index)
+            if not sourceIndex.isValid():
+                continue
             node = SidebarNode.fromIndex(sourceIndex)
             if model.isAncestryChainExpanded(node):
                 self.setCurrentIndex(index)

--- a/gitfourchette/sidebar/sidebar.py
+++ b/gitfourchette/sidebar/sidebar.py
@@ -21,6 +21,7 @@ from gitfourchette.repomodel import RepoModel, UC_FAKEREF
 from gitfourchette.repoprefs import RefSort
 from gitfourchette.sidebar.sidebardelegate import SidebarDelegate, SidebarClickZone
 from gitfourchette.sidebar.sidebarmodel import SidebarModel, SidebarNode, SidebarItem
+from gitfourchette.sidebar.sidebarproxymodel import SidebarProxyModel
 from gitfourchette.tasks import *
 from gitfourchette.toolbox import *
 from gitfourchette.trtables import TrTables
@@ -40,8 +41,8 @@ class Sidebar(QTreeView):
     @property
     def sidebarModel(self) -> SidebarModel:
         model = self.model()
-        assert isinstance(model, SidebarModel)
-        return model
+        assert isinstance(model, SidebarProxyModel)
+        return model.sourceModel()
 
     def __init__(self, parent):
         super().__init__(parent)
@@ -60,13 +61,15 @@ class Sidebar(QTreeView):
         self.customContextMenuRequested.connect(self.onCustomContextMenuRequested)
 
         sidebarModel = SidebarModel(self)
-        self.setModel(sidebarModel)
+        model = SidebarProxyModel(self)
+        model.setSourceModel(sidebarModel)
+        self.setModel(model)
         self.toggleHideRefPattern.connect(sidebarModel.clearCachedTooltip)
 
         self.setItemDelegate(SidebarDelegate(self))
 
-        self.expanded.connect(sidebarModel.onIndexExpanded)
-        self.collapsed.connect(sidebarModel.onIndexCollapsed)
+        self.expanded.connect(self.onIndexExpanded)
+        self.collapsed.connect(self.onIndexCollapsed)
         self.selectionBackup = None
 
         # When clicking on a row, information about the clicked row and "zone"
@@ -79,6 +82,14 @@ class Sidebar(QTreeView):
         makeWidgetShortcut(self, self.onReturnShortcut, "Return", "Enter")
         makeWidgetShortcut(self, self.onDeleteShortcut, "Delete")
         makeWidgetShortcut(self, self.onRenameShortcut, "F2")
+
+    def onIndexExpanded(self, index: QModelIndex):
+        sourceIndex = self.model().mapToSource(index)
+        self.sidebarModel.onIndexExpanded(sourceIndex)
+
+    def onIndexCollapsed(self, index: QModelIndex):
+        sourceIndex = self.model().mapToSource(index)
+        self.sidebarModel.onIndexCollapsed(sourceIndex)
 
     def drawBranches(self, painter, rect, index):
         """
@@ -98,7 +109,8 @@ class Sidebar(QTreeView):
         vr = super().visualRect(index)
 
         if index.isValid():
-            node = SidebarNode.fromIndex(index)
+            sourceIndex = self.model().mapToSource(index)
+            node = SidebarNode.fromIndex(sourceIndex)
             SidebarDelegate.unindentRect(node.kind, vr, self.indentation())
 
         return vr
@@ -519,7 +531,8 @@ class Sidebar(QTreeView):
             if not index.isValid():
                 return
 
-        node = SidebarNode.fromIndex(index)
+        sourceIndex = self.model().mapToSource(index)
+        node = SidebarNode.fromIndex(sourceIndex)
         menu = self.makeNodeMenu(node)
 
         if menu:
@@ -532,7 +545,9 @@ class Sidebar(QTreeView):
 
     def backUpSelection(self):
         try:
-            self.selectionBackup = SidebarNode.fromIndex(self.selectedIndexes()[0])
+            index = self.selectedIndexes()[0]
+            sourceIndex = self.model().mapToSource(index)
+            self.selectionBackup = SidebarNode.fromIndex(sourceIndex)
         except IndexError:
             self.clearSelectionBackup()
 
@@ -544,8 +559,9 @@ class Sidebar(QTreeView):
             return
         with suppress(StopIteration), QSignalBlockerContext(self):
             newNode = self.findNode(self.selectionBackup.isSimilarEnoughTo)
-            restoreIndex = newNode.createIndex(self.sidebarModel)
-            self.setCurrentIndex(restoreIndex)
+            sourceIndex = newNode.createIndex(self.sidebarModel)
+            index = self.model().mapFromSource(sourceIndex)
+            self.setCurrentIndex(index)
         self.clearSelectionBackup()
 
     def refreshPrefs(self):
@@ -554,7 +570,8 @@ class Sidebar(QTreeView):
 
     def repaintUncommittedChanges(self):
         model = self.sidebarModel
-        index = model.nodesByRef[UC_FAKEREF].createIndex(model)
+        sourceIndex = model.nodesByRef[UC_FAKEREF].createIndex(model)
+        index = self.model().mapFromSource(sourceIndex)
         self.update(index)
 
     def wantSelectNode(self, node: SidebarNode):
@@ -717,8 +734,9 @@ class Sidebar(QTreeView):
 
     def getValidNode(self):
         try:
-            index: QModelIndex = self.selectedIndexes()[0]
-            return SidebarNode.fromIndex(index)
+            index = self.selectedIndexes()[0]
+            sourceIndex = self.model().mapToSource(index)
+            return SidebarNode.fromIndex(sourceIndex)
         except IndexError:
             return None
 
@@ -741,13 +759,15 @@ class Sidebar(QTreeView):
         if not current.isValid():
             return
 
-        self.wantSelectNode(SidebarNode.fromIndex(current))
+        sourceIndex = self.model().mapToSource(current)
+        self.wantSelectNode(SidebarNode.fromIndex(sourceIndex))
 
     def resolveClick(self, pos: QPoint) -> tuple[QModelIndex, SidebarNode | None, SidebarClickZone]:
         index = self.indexAt(pos)
         if index.isValid():
             rect = self.visualRect(index)
-            node = SidebarNode.fromIndex(index)
+            sourceIndex = self.model().mapToSource(index)
+            node = SidebarNode.fromIndex(sourceIndex)
             zone = SidebarDelegate.getClickZone(node, rect, pos.x())
         else:
             node = None
@@ -859,12 +879,14 @@ class Sidebar(QTreeView):
         model = self.sidebarModel
         try:
             node = model.nodesByRef[ref]
-            return node.createIndex(model)
+            sourceIndex = node.createIndex(model)
+            return self.model().mapFromSource(sourceIndex)
         except KeyError:
             return None
 
     def selectNode(self, node: SidebarNode) -> QModelIndex:
-        index = node.createIndex(self.sidebarModel)
+        sourceIndex = node.createIndex(self.sidebarModel)
+        index = self.model().mapFromSource(sourceIndex)
         self.setCurrentIndex(index)
         return index
 
@@ -892,7 +914,8 @@ class Sidebar(QTreeView):
             if not index:
                 continue
             # Don't force-expand any collapsed indexes
-            node = SidebarNode.fromIndex(index)
+            sourceIndex = self.model().mapToSource(index)
+            node = SidebarNode.fromIndex(sourceIndex)
             if model.isAncestryChainExpanded(node):
                 self.setCurrentIndex(index)
                 return index
@@ -921,7 +944,8 @@ class Sidebar(QTreeView):
                 continue
 
             if node.wantForceExpand() or node.getCollapseHash() not in model.collapseCache:
-                index = node.createIndex(model)
+                sourceIndex = node.createIndex(model)
+                index = self.model().mapFromSource(sourceIndex)
                 self.expand(index)
 
             frontier.extend(node.children)
@@ -932,7 +956,8 @@ class Sidebar(QTreeView):
             node = frontier.pop()
             if node.kind == SidebarItem.RefFolder:
                 frontier.extend(node.children)
-                index = node.createIndex(self.sidebarModel)
+                sourceIndex = node.createIndex(self.sidebarModel)
+                index = self.model().mapFromSource(sourceIndex)
                 self.collapse(index)
 
     def expandChildFolders(self, node: SidebarNode):
@@ -941,7 +966,8 @@ class Sidebar(QTreeView):
             node = frontier.pop()
             if node.kind == SidebarItem.RefFolder:
                 frontier.extend(node.children)
-                index = node.createIndex(self.sidebarModel)
+                sourceIndex = node.createIndex(self.sidebarModel)
+                index = self.model().mapFromSource(sourceIndex)
                 self.expand(index)
 
     def copyToClipboard(self, text: str):

--- a/gitfourchette/sidebar/sidebardelegate.py
+++ b/gitfourchette/sidebar/sidebardelegate.py
@@ -36,7 +36,10 @@ class SidebarDelegate(QStyledItemDelegate):
     def __init__(self, parent: QTreeView):
         super().__init__(parent)
         self.treeView = parent
-        self.sidebarModel: SidebarModel = parent.model()
+        proxyModel = parent.model()
+        from gitfourchette.sidebar.sidebarproxymodel import SidebarProxyModel
+        assert isinstance(proxyModel, SidebarProxyModel)
+        self.sidebarModel: SidebarModel = proxyModel.sourceModel()
         assert isinstance(self.sidebarModel, SidebarModel)
 
     @staticmethod
@@ -59,7 +62,11 @@ class SidebarDelegate(QStyledItemDelegate):
             return SidebarClickZone.Select
 
     def paint(self, painter: QPainter, option: QStyleOptionViewItem, index: QModelIndex):
-        node = SidebarNode.fromIndex(index)
+        from gitfourchette.sidebar.sidebarproxymodel import SidebarProxyModel
+        proxyModel = self.treeView.model()
+        assert isinstance(proxyModel, SidebarProxyModel)
+        sourceIndex = proxyModel.mapToSource(index)
+        node = SidebarNode.fromIndex(sourceIndex)
         assert node.parent is not None, "can't paint root node"
 
         sidebarModel = self.sidebarModel

--- a/gitfourchette/sidebar/sidebarfilter.py
+++ b/gitfourchette/sidebar/sidebarfilter.py
@@ -1,0 +1,47 @@
+# -----------------------------------------------------------------------------
+# Copyright (C) 2026 Iliyas Jorio.
+# This file is part of GitFourchette, distributed under the GNU GPL v3.
+# For full terms, see the included LICENSE file.
+# -----------------------------------------------------------------------------
+
+from gitfourchette.localization import *
+from gitfourchette.qt import *
+from gitfourchette.toolbox import stockIcon
+
+
+class SidebarFilter(QWidget):
+    textChanged = Signal(str)
+
+    @property
+    def lineEdit(self) -> QLineEdit:
+        return self._lineEdit
+
+    @property
+    def filterText(self) -> str:
+        return self._lineEdit.text()
+
+    def __init__(self, parent: QWidget):
+        super().__init__(parent)
+
+        self.setObjectName("SidebarFilter")
+
+        self._lineEdit = QLineEdit(self)
+        self._lineEdit.setPlaceholderText(_("Filter branches, tags, stashes…"))
+        self._lineEdit.setClearButtonEnabled(True)
+        self._lineEdit.setStyleSheet("border: 1px solid gray; border-radius: 5px;")
+        self._lineEdit.addAction(stockIcon("magnifying-glass"), QLineEdit.ActionPosition.LeadingPosition)
+        self._lineEdit.textChanged.connect(self._onTextChanged)
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(4, 4, 4, 4)
+        layout.addWidget(self._lineEdit)
+
+    def _onTextChanged(self, text: str):
+        self.textChanged.emit(text)
+
+    def clear(self):
+        self._lineEdit.clear()
+
+    def setFocus(self):
+        self._lineEdit.setFocus()
+        self._lineEdit.selectAll()

--- a/gitfourchette/sidebar/sidebarproxymodel.py
+++ b/gitfourchette/sidebar/sidebarproxymodel.py
@@ -60,7 +60,9 @@ class SidebarProxyModel(QSortFilterProxyModel):
             if not displayText:
                 return True
 
-            if item == SidebarItem.Stash:
+            # For branches and tags, check both display text and full ref path
+            # This ensures that branches like "wip/leaf" match when searching for "wip"
+            if item in [SidebarItem.LocalBranch, SidebarItem.RemoteBranch, SidebarItem.Tag, SidebarItem.Stash]:
                 refName = index.data(sourceModel.Role.Ref)
                 if refName and self._filterText.lower() in refName.lower():
                     return True

--- a/gitfourchette/sidebar/sidebarproxymodel.py
+++ b/gitfourchette/sidebar/sidebarproxymodel.py
@@ -1,0 +1,70 @@
+# -----------------------------------------------------------------------------
+# Copyright (C) 2026 Iliyas Jorio.
+# This file is part of GitFourchette, distributed under the GNU GPL v3.
+# For full terms, see the included LICENSE file.
+# -----------------------------------------------------------------------------
+
+from gitfourchette.qt import *
+from gitfourchette.sidebar.sidebarmodel import SidebarNode, SidebarItem
+
+
+class SidebarProxyModel(QSortFilterProxyModel):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._filterText = ""
+        self.setRecursiveFilteringEnabled(True)
+        self.setFilterCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
+
+    def setFilterText(self, text: str):
+        self._filterText = text.strip()
+        self.invalidateFilter()
+
+    def filterAcceptsRow(self, sourceRow: int, sourceParent: QModelIndex) -> bool:
+        if not self._filterText:
+            return True
+
+        sourceModel = self.sourceModel()
+        index = sourceModel.index(sourceRow, 0, sourceParent)
+
+        if not index.isValid():
+            return True
+
+        node = SidebarNode.fromIndex(index)
+        item = node.kind
+
+        if item in [
+            SidebarItem.Root,
+            SidebarItem.Spacer,
+            SidebarItem.WorkdirHeader,
+            SidebarItem.UncommittedChanges,
+            SidebarItem.LocalBranchesHeader,
+            SidebarItem.RemotesHeader,
+            SidebarItem.TagsHeader,
+            SidebarItem.StashesHeader,
+            SidebarItem.SubmodulesHeader,
+        ]:
+            return True
+
+        if item in [
+            SidebarItem.LocalBranch,
+            SidebarItem.RemoteBranch,
+            SidebarItem.Tag,
+            SidebarItem.Stash,
+            SidebarItem.Remote,
+            SidebarItem.RefFolder,
+            SidebarItem.Submodule,
+            SidebarItem.DetachedHead,
+            SidebarItem.UnbornHead,
+        ]:
+            displayText = index.data(Qt.ItemDataRole.DisplayRole)
+            if not displayText:
+                return True
+
+            if item == SidebarItem.Stash:
+                refName = index.data(sourceModel.Role.Ref)
+                if refName and self._filterText.lower() in refName.lower():
+                    return True
+
+            return self._filterText.lower() in displayText.lower()
+
+        return True

--- a/test/test_gitfourchette.py
+++ b/test/test_gitfourchette.py
@@ -862,3 +862,94 @@ def testAccumulateTaskEffectBitsUntilRefreshAbortedManually(tempDir, mainWindow,
         # file1.txt still appears dirty because we've aborted the refresh task
         assert 1 == len(qlvGetRowData(rw.dirtyFiles))
         waitUntilTrue(lambda: not rw.taskRunner.isBusy())
+
+
+def testSidebarFilterIntegration(tempDir, mainWindow):
+    wd = unpackRepo(tempDir)
+
+    with RepoContext(wd) as repo:
+        repo.create_branch_on_head("feature/login")
+        repo.create_branch_on_head("feature/signup")
+        repo.create_branch_on_head("bugfix/issue-123")
+
+    rw = mainWindow.openRepo(wd)
+    sb = rw.sidebar
+    sidebarFilter = rw.sidebarFilter
+
+    # Verify filter widget is visible
+    assert sidebarFilter.isVisible()
+
+    # Test filtering branches
+    sidebarFilter.lineEdit.setText("feature")
+    QTest.qWait(50)
+
+    # Should be able to navigate to filtered branch
+    featureNode = sb.findNodeByRef("refs/heads/feature/login")
+    assert featureNode is not None
+
+    # Clear filter
+    sidebarFilter.clear()
+    QTest.qWait(50)
+    assert sidebarFilter.filterText == ""
+
+
+def testSidebarFilterPersistsAcrossRefresh(tempDir, mainWindow):
+    wd = unpackRepo(tempDir)
+
+    with RepoContext(wd) as repo:
+        repo.create_branch_on_head("feature/test")
+        repo.create_branch_on_head("bugfix/test")
+
+    rw = mainWindow.openRepo(wd)
+    sidebarFilter = rw.sidebarFilter
+
+    # Apply filter
+    sidebarFilter.lineEdit.setText("feature")
+    QTest.qWait(50)
+    assert sidebarFilter.filterText == "feature"
+
+    # Refresh repo
+    rw.refreshRepo()
+
+    # Filter should still be applied
+    assert sidebarFilter.filterText == "feature"
+
+
+def testSidebarFilterWithRemoteBranches(tempDir, mainWindow):
+    wd = unpackRepo(tempDir)
+    rw = mainWindow.openRepo(wd)
+    sb = rw.sidebar
+    sidebarFilter = rw.sidebarFilter
+
+    # Test filtering remote branches
+    sidebarFilter.lineEdit.setText("origin")
+    QTest.qWait(50)
+
+    # Remote node should be visible
+    originNode = sb.findNode(lambda n: n.data == "origin")
+    assert originNode is not None
+
+    # Clear filter
+    sidebarFilter.clear()
+    QTest.qWait(50)
+
+
+def testSidebarFilterKeyboardShortcuts(tempDir, mainWindow):
+    wd = unpackRepo(tempDir)
+    rw = mainWindow.openRepo(wd)
+    sb = rw.sidebar
+    sidebarFilter = rw.sidebarFilter
+
+    # Test typing in filter
+    sidebarFilter.lineEdit.setText("master")
+    QTest.qWait(50)
+    assert sidebarFilter.filterText == "master"
+    
+    # Should be able to find master branch when filtered
+    masterNode = sb.findNodeByRef("refs/heads/master")
+    assert masterNode is not None
+
+    # Test clearing filter programmatically
+    sidebarFilter.clear()
+    QTest.qWait(50)
+    assert sidebarFilter.filterText == ""

--- a/test/test_gitfourchette.py
+++ b/test/test_gitfourchette.py
@@ -529,9 +529,10 @@ def testRestoreSession(tempDir, mainWindow):
 
     # Collapse something in sidebar
     originNode = rw.sidebar.findNodeByKind(SidebarItem.Remote)
-    originIndex = originNode.createIndex(rw.sidebar.sidebarModel)
+    originSourceIndex = originNode.createIndex(rw.sidebar.sidebarModel)
+    originIndex = rw.sidebar.model().mapFromSource(originSourceIndex)
     assert rw.sidebar.isExpanded(originIndex)
-    rw.sidebar.collapse(originNode.createIndex(rw.sidebar.sidebarModel))
+    rw.sidebar.collapse(originIndex)
     assert not rw.sidebar.isExpanded(originIndex)
 
     # Hide something in sidebar
@@ -944,7 +945,7 @@ def testSidebarFilterKeyboardShortcuts(tempDir, mainWindow):
     sidebarFilter.lineEdit.setText("master")
     QTest.qWait(50)
     assert sidebarFilter.filterText == "master"
-    
+
     # Should be able to find master branch when filtered
     masterNode = sb.findNodeByRef("refs/heads/master")
     assert masterNode is not None

--- a/test/test_sidebar.py
+++ b/test/test_sidebar.py
@@ -529,32 +529,33 @@ def testSidebarFilter(tempDir, mainWindow):
 
     # Test filtering by "feature"
     sidebarFilter.lineEdit.setText("feature")
-    QTest.qWait(50)  # Wait for filter to apply
 
-    # Check that feature branches can still be found
-    featureLogin = sb.findNodeByRef("refs/heads/feature/login")
-    assert featureLogin is not None
-    featureSignup = sb.findNodeByRef("refs/heads/feature/signup")
-    assert featureSignup is not None
+    # Visible: feature branches
+    assert sb.indexForRef("refs/heads/feature/login").isValid()
+    assert sb.indexForRef("refs/heads/feature/signup").isValid()
+    # Hidden: unrelated branches
+    assert not sb.indexForRef("refs/heads/no-parent").isValid()
+    assert not sb.indexForRef("refs/heads/master").isValid()
 
     # Test clearing filter
     sidebarFilter.clear()
-    QTest.qWait(50)
     assert sidebarFilter.filterText == ""
+    # All branches visible again after clearing
+    assert sb.indexForRef("refs/heads/master").isValid()
+    assert sb.indexForRef("refs/heads/no-parent").isValid()
 
     # Test case-insensitive filtering
     sidebarFilter.lineEdit.setText("FEATURE")
-    QTest.qWait(50)
-    featureLogin = sb.findNodeByRef("refs/heads/feature/login")
-    assert featureLogin is not None
+    assert sb.indexForRef("refs/heads/feature/login").isValid()
+    assert sb.indexForRef("refs/heads/feature/signup").isValid()
+    assert not sb.indexForRef("refs/heads/no-parent").isValid()
 
     # Test substring matching
     sidebarFilter.lineEdit.setText("fix")
-    QTest.qWait(50)
-    bugfixBranch = sb.findNodeByRef("refs/heads/bugfix/issue-123")
-    assert bugfixBranch is not None
-    hotfixBranch = sb.findNodeByRef("refs/heads/hotfix/critical")
-    assert hotfixBranch is not None
+    assert sb.indexForRef("refs/heads/bugfix/issue-123").isValid()
+    assert sb.indexForRef("refs/heads/hotfix/critical").isValid()
+    # "no-parent" doesn't contain "fix", so it must be hidden
+    assert not sb.indexForRef("refs/heads/no-parent").isValid()
 
 
 def testSidebarFilterWithFolders(tempDir, mainWindow):
@@ -569,13 +570,11 @@ def testSidebarFilterWithFolders(tempDir, mainWindow):
     sb = rw.sidebar
     sidebarFilter = rw.sidebarFilter
 
-    # Test filtering shows parent folders
+    # Filtering by "login" should show the matching branch and hide others
     sidebarFilter.lineEdit.setText("login")
-    QTest.qWait(50)
-
-    # Should be able to find the branch
-    loginNode = sb.findNodeByRef("refs/heads/team/frontend/login")
-    assert loginNode is not None
+    assert sb.indexForRef("refs/heads/team/frontend/login").isValid()
+    assert not sb.indexForRef("refs/heads/team/backend/api").isValid()
+    assert not sb.indexForRef("refs/heads/team/frontend/signup").isValid()
 
 
 def testSidebarFilterKeyboardShortcuts(tempDir, mainWindow):
@@ -589,7 +588,6 @@ def testSidebarFilterKeyboardShortcuts(tempDir, mainWindow):
 
     # Test clearing filter
     sidebarFilter.clear()
-    QTest.qWait(50)
     assert sidebarFilter.filterText == ""
 
 
@@ -605,13 +603,11 @@ def testSidebarFilterWithTags(tempDir, mainWindow):
     sb = rw.sidebar
     sidebarFilter = rw.sidebarFilter
 
-    # Test filtering tags
+    # Filtering by "v1" should show v1.0.0 and hide the others
     sidebarFilter.lineEdit.setText("v1")
-    QTest.qWait(50)
-
-    # Should be able to find v1.0.0 tag
-    v1Tag = sb.findNodeByRef("refs/tags/v1.0.0")
-    assert v1Tag is not None
+    assert sb.indexForRef("refs/tags/v1.0.0").isValid()
+    assert not sb.indexForRef("refs/tags/v2.0.0").isValid()
+    assert not sb.indexForRef("refs/tags/release-2024").isValid()
 
 
 def testSidebarFilterPreservesSelection(tempDir, mainWindow):
@@ -631,11 +627,11 @@ def testSidebarFilterPreservesSelection(tempDir, mainWindow):
     selectedBefore = sb.selectedIndexes()[0].data()
     assert "test" in selectedBefore
 
-    # Filter should not affect selection if item matches
+    # Filter that keeps the selected item visible
     sidebarFilter.lineEdit.setText("feature")
-    QTest.qWait(50)
 
-    # Selection should still be valid
+    # The selected item should still be visible in the proxy model
+    assert sb.indexForRef("refs/heads/feature/test").isValid()
     assert len(sb.selectedIndexes()) > 0
 
 
@@ -648,12 +644,22 @@ def testSidebarFilterExpandsAll(tempDir, mainWindow):
 
     rw = mainWindow.openRepo(wd)
     sb = rw.sidebar
+    sm = sb.sidebarModel
     sidebarFilter = rw.sidebarFilter
 
-    # Apply filter - should expand all
-    sidebarFilter.lineEdit.setText("login")
-    QTest.qWait(50)
+    # Collapse all folders first so we have something to expand
+    localBranchesNode = sb.findNodeByKind(SidebarItem.LocalBranchesHeader)
+    sb.selectNode(localBranchesNode)
+    triggerContextMenuAction(sb.viewport(), "collapse all folders")
 
-    # Should be able to find the login branch
+    # Confirm the nested branch is now unreachable (ancestry chain collapsed)
     loginNode = sb.findNodeByRef("refs/heads/team/frontend/login")
-    assert loginNode is not None
+    assert not sm.isAncestryChainExpanded(loginNode)
+
+    # Applying a filter should expand all matching items
+    sidebarFilter.lineEdit.setText("login")
+
+    # The branch must now be visible in the proxy model
+    assert sb.indexForRef("refs/heads/team/frontend/login").isValid()
+    # And its entire parent chain must be expanded in the source model
+    assert sm.isAncestryChainExpanded(loginNode)

--- a/test/test_sidebar.py
+++ b/test/test_sidebar.py
@@ -502,3 +502,154 @@ def testSidebarMissingUpstream(tempDir, mainWindow):
 
     # If we ever choose to not disable this action, the action callback should be tested as well.
     assert not missingUpstreamAction.isEnabled()
+
+
+def testSidebarFilter(tempDir, mainWindow):
+    wd = unpackRepo(tempDir)
+
+    with RepoContext(wd) as repo:
+        repo.create_branch_on_head("feature/login")
+        repo.create_branch_on_head("feature/signup")
+        repo.create_branch_on_head("bugfix/issue-123")
+        repo.create_branch_on_head("hotfix/critical")
+
+    rw = mainWindow.openRepo(wd)
+    sb = rw.sidebar
+    sidebarFilter = rw.sidebarFilter
+
+    # Test initial state
+    assert sidebarFilter.filterText == ""
+    allBranches = sb.findNodesByKind(SidebarItem.LocalBranch)
+    assert len(allBranches) >= 6  # master, no-parent, feature/*, bugfix/*, hotfix/*
+
+    # Test filtering by "feature"
+    sidebarFilter.lineEdit.setText("feature")
+    QTest.qWait(50)  # Wait for filter to apply
+    
+    # Check that feature branches can still be found
+    featureLogin = sb.findNodeByRef("refs/heads/feature/login")
+    assert featureLogin is not None
+    featureSignup = sb.findNodeByRef("refs/heads/feature/signup")
+    assert featureSignup is not None
+
+    # Test clearing filter
+    sidebarFilter.clear()
+    QTest.qWait(50)
+    assert sidebarFilter.filterText == ""
+
+    # Test case-insensitive filtering
+    sidebarFilter.lineEdit.setText("FEATURE")
+    QTest.qWait(50)
+    featureLogin = sb.findNodeByRef("refs/heads/feature/login")
+    assert featureLogin is not None
+
+    # Test substring matching
+    sidebarFilter.lineEdit.setText("fix")
+    QTest.qWait(50)
+    bugfixBranch = sb.findNodeByRef("refs/heads/bugfix/issue-123")
+    assert bugfixBranch is not None
+    hotfixBranch = sb.findNodeByRef("refs/heads/hotfix/critical")
+    assert hotfixBranch is not None
+
+
+def testSidebarFilterWithFolders(tempDir, mainWindow):
+    wd = unpackRepo(tempDir)
+
+    with RepoContext(wd) as repo:
+        repo.create_branch_on_head("team/frontend/login")
+        repo.create_branch_on_head("team/frontend/signup")
+        repo.create_branch_on_head("team/backend/api")
+
+    rw = mainWindow.openRepo(wd)
+    sb = rw.sidebar
+    sidebarFilter = rw.sidebarFilter
+
+    # Test filtering shows parent folders
+    sidebarFilter.lineEdit.setText("login")
+    QTest.qWait(50)
+
+    # Should be able to find the branch
+    loginNode = sb.findNodeByRef("refs/heads/team/frontend/login")
+    assert loginNode is not None
+
+
+def testSidebarFilterKeyboardShortcuts(tempDir, mainWindow):
+    wd = unpackRepo(tempDir)
+    rw = mainWindow.openRepo(wd)
+    sb = rw.sidebar
+    sidebarFilter = rw.sidebarFilter
+
+    # Test setting filter text
+    sidebarFilter.lineEdit.setText("test")
+    assert sidebarFilter.filterText == "test"
+    
+    # Test clearing filter
+    sidebarFilter.clear()
+    QTest.qWait(50)
+    assert sidebarFilter.filterText == ""
+
+
+def testSidebarFilterWithTags(tempDir, mainWindow):
+    wd = unpackRepo(tempDir)
+
+    with RepoContext(wd) as repo:
+        repo.create_tag("v1.0.0", repo.head_commit_id, ObjectType.COMMIT, TEST_SIGNATURE, "")
+        repo.create_tag("v2.0.0", repo.head_commit_id, ObjectType.COMMIT, TEST_SIGNATURE, "")
+        repo.create_tag("release-2024", repo.head_commit_id, ObjectType.COMMIT, TEST_SIGNATURE, "")
+
+    rw = mainWindow.openRepo(wd)
+    sb = rw.sidebar
+    sidebarFilter = rw.sidebarFilter
+
+    # Test filtering tags
+    sidebarFilter.lineEdit.setText("v1")
+    QTest.qWait(50)
+
+    # Should be able to find v1.0.0 tag
+    v1Tag = sb.findNodeByRef("refs/tags/v1.0.0")
+    assert v1Tag is not None
+
+
+def testSidebarFilterPreservesSelection(tempDir, mainWindow):
+    wd = unpackRepo(tempDir)
+
+    with RepoContext(wd) as repo:
+        repo.create_branch_on_head("feature/test")
+
+    rw = mainWindow.openRepo(wd)
+    sb = rw.sidebar
+    sidebarFilter = rw.sidebarFilter
+
+    # Select a branch
+    featureNode = sb.findNodeByRef("refs/heads/feature/test")
+    sb.selectNode(featureNode)
+    
+    selectedBefore = sb.selectedIndexes()[0].data()
+    assert "test" in selectedBefore
+
+    # Filter should not affect selection if item matches
+    sidebarFilter.lineEdit.setText("feature")
+    QTest.qWait(50)
+    
+    # Selection should still be valid
+    assert len(sb.selectedIndexes()) > 0
+
+
+def testSidebarFilterExpandsAll(tempDir, mainWindow):
+    wd = unpackRepo(tempDir)
+
+    with RepoContext(wd) as repo:
+        repo.create_branch_on_head("team/frontend/login")
+        repo.create_branch_on_head("team/backend/api")
+
+    rw = mainWindow.openRepo(wd)
+    sb = rw.sidebar
+    sidebarFilter = rw.sidebarFilter
+
+    # Apply filter - should expand all
+    sidebarFilter.lineEdit.setText("login")
+    QTest.qWait(50)
+
+    # Should be able to find the login branch
+    loginNode = sb.findNodeByRef("refs/heads/team/frontend/login")
+    assert loginNode is not None

--- a/test/test_sidebar.py
+++ b/test/test_sidebar.py
@@ -74,7 +74,8 @@ def testSidebarCollapsePersistent(tempDir, mainWindow):
     sb = rw.sidebar
     sm = sb.sidebarModel
     assert sm.isAncestryChainExpanded(sb.findNodeByRef("refs/remotes/origin/master"))
-    indexToCollapse = sb.findNode(lambda n: n.data == "origin").createIndex(sm)
+    sourceIndexToCollapse = sb.findNode(lambda n: n.data == "origin").createIndex(sm)
+    indexToCollapse = sb.model().mapFromSource(sourceIndexToCollapse)
     sb.collapse(indexToCollapse)
     sb.expand(indexToCollapse)  # go through both expand/collapse code paths
     sb.collapse(indexToCollapse)
@@ -141,7 +142,8 @@ def testSidebarCollapseExpandAllFolders(tempDir, mainWindow):
     triggerContextMenuAction(sb.viewport(), "collapse all folders")
     assert reachable() == {delish}
 
-    sb.expand(delish.createIndex(sm))
+    proxyIndex = sb.model().mapFromSource(delish.createIndex(sm))
+    sb.expand(proxyIndex)
     assert reachable() == {delish, quiche, drink}
 
     triggerContextMenuAction(sb.viewport(), "expand all folders")
@@ -159,7 +161,8 @@ def testRefreshKeepsSidebarNonRefSelection(tempDir, mainWindow):
     sb.selectNode(node)
 
     rw.refreshRepo()
-    node = SidebarNode.fromIndex(sb.selectedIndexes()[0])
+    sourceIndex = sb.model().mapToSource(sb.selectedIndexes()[0])
+    node = SidebarNode.fromIndex(sourceIndex)
     assert node.kind == SidebarItem.Remote
     assert node.data == "origin"
 
@@ -278,7 +281,8 @@ def testHideNestedRefFolders(tempDir, mainWindow, explicit, implicit, method):
     if method == "sidebarmenu":
         triggerMenuAction(sb.makeNodeMenu(node), "hide in graph")
     elif method == "sidebarclick":
-        index = node.createIndex(sm)
+        sourceIndex = node.createIndex(sm)
+        index = sb.model().mapFromSource(sourceIndex)
         rect = sb.visualRect(index)
         QTest.mouseClick(sb.viewport(), Qt.MouseButton.LeftButton, pos=rect.topRight())
     else:
@@ -336,7 +340,8 @@ def testHideAllButThis(tempDir, mainWindow, explicit, implicit, method):
     if method == "sidebarmenu":
         triggerMenuAction(sb.makeNodeMenu(node), "hide all but this")
     elif method == "sidebarclick":
-        index = node.createIndex(sm)
+        sourceIndex = node.createIndex(sm)
+        index = sb.model().mapFromSource(sourceIndex)
         rect = sb.visualRect(index)
         QTest.mouseClick(sb.viewport(), Qt.MouseButton.MiddleButton, pos=rect.topRight())
     else:
@@ -525,7 +530,7 @@ def testSidebarFilter(tempDir, mainWindow):
     # Test filtering by "feature"
     sidebarFilter.lineEdit.setText("feature")
     QTest.qWait(50)  # Wait for filter to apply
-    
+
     # Check that feature branches can still be found
     featureLogin = sb.findNodeByRef("refs/heads/feature/login")
     assert featureLogin is not None
@@ -576,13 +581,12 @@ def testSidebarFilterWithFolders(tempDir, mainWindow):
 def testSidebarFilterKeyboardShortcuts(tempDir, mainWindow):
     wd = unpackRepo(tempDir)
     rw = mainWindow.openRepo(wd)
-    sb = rw.sidebar
     sidebarFilter = rw.sidebarFilter
 
     # Test setting filter text
     sidebarFilter.lineEdit.setText("test")
     assert sidebarFilter.filterText == "test"
-    
+
     # Test clearing filter
     sidebarFilter.clear()
     QTest.qWait(50)
@@ -623,14 +627,14 @@ def testSidebarFilterPreservesSelection(tempDir, mainWindow):
     # Select a branch
     featureNode = sb.findNodeByRef("refs/heads/feature/test")
     sb.selectNode(featureNode)
-    
+
     selectedBefore = sb.selectedIndexes()[0].data()
     assert "test" in selectedBefore
 
     # Filter should not affect selection if item matches
     sidebarFilter.lineEdit.setText("feature")
     QTest.qWait(50)
-    
+
     # Selection should still be valid
     assert len(sb.selectedIndexes()) > 0
 

--- a/test/test_tasks_branch.py
+++ b/test/test_tasks_branch.py
@@ -37,7 +37,9 @@ def testNewBranch(tempDir, mainWindow, method, switch):
         sb.selectNode(node)
         QTest.keyPress(sb, Qt.Key.Key_Return)
     elif method == "sidebardclick":
-        rect = sb.visualRect(node.createIndex(sb.sidebarModel))
+        sourceIndex = node.createIndex(sb.sidebarModel)
+        index = sb.model().mapFromSource(sourceIndex)
+        rect = sb.visualRect(index)
         QTest.mouseDClick(sb.viewport(), Qt.MouseButton.LeftButton, pos=rect.topLeft())
     elif method == "shortcut":
         QTest.qWait(0)
@@ -929,7 +931,9 @@ def testMergeFastForward(tempDir, mainWindow, method):
     assert rw.repo.head.target != rw.repo.branches.local['master'].target
 
     node = rw.sidebar.findNodeByRef("refs/heads/master")
-    rw.sidebar.setCurrentIndex(node.createIndex(rw.sidebar.sidebarModel))
+    sourceIndex = node.createIndex(rw.sidebar.sidebarModel)
+    proxyIndex = rw.sidebar.model().mapFromSource(sourceIndex)
+    rw.sidebar.setCurrentIndex(proxyIndex)
 
     if method == "sidebar":
         menu = rw.sidebar.makeNodeMenu(node)

--- a/test/test_tasks_commit.py
+++ b/test/test_tasks_commit.py
@@ -463,7 +463,8 @@ def testDetachHeadOnSameCommitAsCheckedOutBranch(tempDir, mainWindow):
     assert rw.repo.head_commit_id == headId
 
     # Sidebar must now reflect detached HEAD
-    currentSidebarNode = SidebarNode.fromIndex(rw.sidebar.currentIndex())
+    sourceIndex = rw.sidebar.model().mapToSource(rw.sidebar.currentIndex())
+    currentSidebarNode = SidebarNode.fromIndex(sourceIndex)
     assert currentSidebarNode.kind == SidebarItem.DetachedHead
 
 
@@ -764,7 +765,9 @@ def testCheckoutTag(tempDir, mainWindow, method):
         sb.selectNode(node)
         QTest.keyPress(rw.sidebar, Qt.Key.Key_Return)
     elif method == "sidebardclick":
-        rect = sb.visualRect(node.createIndex(sb.sidebarModel))
+        sourceIndex = node.createIndex(sb.sidebarModel)
+        index = sb.model().mapFromSource(sourceIndex)
+        rect = sb.visualRect(index)
         QTest.mouseDClick(sb.viewport(), Qt.MouseButton.LeftButton, pos=rect.topLeft())
     else:
         raise NotImplementedError(f"unknown method {method}")

--- a/test/test_tasks_stash.py
+++ b/test/test_tasks_stash.py
@@ -42,7 +42,9 @@ def testNewStash(tempDir, mainWindow, method):
         sb.selectNode(node)
         QTest.keyPress(sb, Qt.Key.Key_Return)
     elif method == "sidebardclick":
-        rect = sb.visualRect(node.createIndex(rw.sidebar.sidebarModel))
+        sourceIndex = node.createIndex(rw.sidebar.sidebarModel)
+        index = sb.model().mapFromSource(sourceIndex)
+        rect = sb.visualRect(index)
         QTest.mouseDClick(sb.viewport(), Qt.MouseButton.LeftButton, pos=rect.topLeft())
     elif method == "menubar":
         triggerMenuAction(mainWindow.menuBar(), "repo/stash")
@@ -231,7 +233,9 @@ def testApplyStash(tempDir, mainWindow, method):
         rw.sidebar.selectNode(node)
         QTest.keyPress(rw.sidebar, Qt.Key.Key_Return)
     elif method == "sidebardclick":
-        rect = rw.sidebar.visualRect(node.createIndex(rw.sidebar.sidebarModel))
+        sourceIndex = node.createIndex(rw.sidebar.sidebarModel)
+        index = rw.sidebar.model().mapFromSource(sourceIndex)
+        rect = rw.sidebar.visualRect(index)
         QTest.mouseDClick(rw.sidebar.viewport(), Qt.MouseButton.LeftButton, pos=rect.topLeft())
     else:
         raise NotImplementedError(f"unknown method {method}")

--- a/test/test_tasks_submodule.py
+++ b/test/test_tasks_submodule.py
@@ -43,7 +43,9 @@ def testOpenSubmoduleWithinApp(tempDir, mainWindow, method):
         QTest.keyPress(rw.sidebar, Qt.Key.Key_Return)
 
     elif method == "sidebarDClick":
-        rect = rw.sidebar.visualRect(submoNode.createIndex(rw.sidebar.sidebarModel))
+        sourceIndex = submoNode.createIndex(rw.sidebar.sidebarModel)
+        index = rw.sidebar.model().mapFromSource(sourceIndex)
+        rect = rw.sidebar.visualRect(index)
         QTest.mouseDClick(rw.sidebar.viewport(), Qt.MouseButton.LeftButton, pos=rect.topLeft())
 
     elif method == "commitSpecialDiff":

--- a/test/test_usercommands.py
+++ b/test/test_usercommands.py
@@ -192,7 +192,8 @@ def testUserCommandTokens(tempDir, mainWindow, commandsScratchFile, params):
         menu = summonContextMenu(rw.committedFiles.viewport())
         action = findMenuAction(menu, r"\(command\) " + params.menuName)
     elif params.actionSource == "sidebar":
-        node = SidebarNode.fromIndex(rw.sidebar.selectedIndexes()[0])
+        sourceIndex = rw.sidebar.model().mapToSource(rw.sidebar.selectedIndexes()[0])
+        node = SidebarNode.fromIndex(sourceIndex)
         menu = rw.sidebar.makeNodeMenu(node)
         action = findMenuAction(menu, r"\(command\) " + params.menuName)
     else:


### PR DESCRIPTION
## Summary

Adds a filter input at the top of the sidebar to quickly locate branches, tags, stashes, remotes, and submodules by name.

Fixes #99

## Changes

- **New files:**
  - `gitfourchette/sidebar/sidebarfilter.py` - Filter input widget
  - `gitfourchette/sidebar/sidebarproxymodel.py` - QSortFilterProxyModel for filtering

- **Modified files:**
  - `gitfourchette/sidebar/sidebar.py` - Updated to use proxy model for filtering
  - `gitfourchette/sidebar/sidebardelegate.py` - Updated to work with proxy model
  - `gitfourchette/repowidget.py` - Integrated filter widget into sidebar container

## Features

- **Real-time filtering** as you type
- **Substring matching** (case-insensitive) - e.g., typing "fix" shows "bugfix/issue-123"
- **Preserves hierarchy** - shows parent folders when children match
- **Auto-expand** - expands all items when filtering to show matches
- **Keyboard shortcuts:**
  - Press `/` to focus the filter
  - Press `Escape` to clear the filter
- **Always visible** at the top of the sidebar

## Testing

Tested with repositories containing:
- Multiple local branches with nested folders
- Remote branches
- Tags
- Stashes
- Various naming patterns

All existing sidebar functionality (context menus, selection, expand/collapse, hide patterns) continues to work as expected.

## Screenshots

<img width="1207" height="742" alt="image" src="https://github.com/user-attachments/assets/e778edb1-92e7-4bf3-a12f-53483fb4c529" />

