### PR TITLE
Fix stash deletion failing when trash is disabled

### DIFF
--- a/gitfourchette/tasks/stashtasks.py
+++ b/gitfourchette/tasks/stashtasks.py
@@ -5,6 +5,7 @@
 # -----------------------------------------------------------------------------
 
 import itertools
+import logging
 
 from gitfourchette.forms.stashdialog import StashDialog
 from gitfourchette.localization import *
@@ -14,6 +15,8 @@ from gitfourchette.qt import *
 from gitfourchette.tasks.repotask import AbortTask, RepoTask, TaskEffects, TaskPrereqs
 from gitfourchette.toolbox import *
 from gitfourchette.trash import Trash
+
+logger = logging.getLogger(__name__)
 
 _indexStatusTable = {
     "A": FileStatus.INDEX_NEW,
@@ -40,9 +43,10 @@ Vanilla git unstaged file status to libgit2 worktree status flags
 
 
 def backupStash(repo: Repo, stashCommitId: Oid):
-    trashFile = Trash.instance().newFile(repo.workdir, ext=".txt", originalPath="DELETED_STASH")
-
-    if not trashFile:
+    try:
+        trashFile = Trash.instance().newFile(repo.workdir, ext=".txt", originalPath="DELETED_STASH")
+    except Trash.BackupSkipped as ex:
+        logger.warning(f"Stash backup skipped: {ex}")
         return
 
     text = F"""\


### PR DESCRIPTION
### Problem
`backupStash()` calls `Trash.instance().newFile()`, which calls `ensureTrashEnabled()` and raises `Trash.BackupSkipped` when the trash is disabled (`maxTrashFiles == 0`, a supported preference value). `backupStash` doesn't catch it, so the exception propagates out of `DropStash` and out of `ApplyStash` when "delete the stash if it applies cleanly" is ticked.

The existing `if not trashFile: return` guard is dead code — `newFile()` never returns `None`; it either returns a `Path` or raises.

### Repro
1. Preferences → set the trash to keep **0** discarded patches.
2. Drop a stash (or apply-and-delete a stash).
3. The task aborts with an error dialog and the stash is never removed.

### Fix
Catch `Trash.BackupSkipped` in `backupStash` and skip the backup, mirroring how `DiscardFiles` already handles the same exception. Added a module logger for the warning.

---
*Prepared with Claude Fable 5 (Low effort mode).*
