### PR TITLE
Close stdin after writing to prevent LFS smudge hang

### DIFF
--- a/gitfourchette/tasks/repotask.py
+++ b/gitfourchette/tasks/repotask.py
@@ -503,6 +503,9 @@ class RepoTask(QObject):
             yield from processWrapper.coWaitStart()
             if stdin:
                 process.write(stdin.encode("utf-8"))
+                # Close the write channel so children that read stdin to EOF
+                # (e.g. 'git lfs smudge') don't block forever.
+                process.closeWriteChannel()
             yield from processWrapper.coWaitFinished(autoFail)
         finally:
             self._currentProcess = None


### PR DESCRIPTION
### Problem
`RepoTask.flowStartProcess` writes to the child process's stdin but never closes the write channel:

```python
if stdin:
    process.write(stdin.encode("utf-8"))
```

`DownloadLfsObjects` pipes an LFS pointer into `git lfs smudge`, which reads stdin until EOF. With the write channel left open, `smudge` blocks forever waiting for EOF, the task never finishes, and the UI stays busy.

### Repro
Open a diff of an LFS-tracked file whose object isn't cached locally → the smudge task hangs indefinitely.

### Fix
Call `process.closeWriteChannel()` after writing stdin, so children that read to EOF terminate normally.

---
*Prepared with Claude Fable 5 (Low effort mode).*
