### PR TITLE
Guard git status parser against infinite loop on unknown entry

### DIFF
--- a/gitfourchette/gitdriver/parsers.py
+++ b/gitfourchette/gitdriver/parsers.py
@@ -79,13 +79,19 @@ def parseGitStatus(stdout: str, workdir: str):
 
     while pos < limit:
         ident = stdout[pos]
-        try:
-            pattern = _gitStatusPatterns[ident]
-        except KeyError:
-            logging.warning(f"unknown git status ident '{ident}'")
+        pattern = _gitStatusPatterns.get(ident)
+        match = pattern.match(stdout, pos) if pattern is not None else None
+
+        if match is None:
+            # Unknown ident or malformed record. Skip to the next NUL-terminated
+            # entry rather than re-reading the same character forever.
+            logging.warning(f"skipping unparseable git status entry (ident '{ident}')")
+            nul = stdout.find("\x00", pos)
+            if nul < 0:
+                break
+            pos = nul + 1
             continue
 
-        match = pattern.match(stdout, pos)
         pos = match.end()
 
         staged, unstaged = _parseStatusLine(ident, *match.groups())


### PR DESCRIPTION
### Problem
In `parseGitStatus`, `pos` is only advanced from `match.end()` after a successful pattern lookup. On an unrecognized status ident the code hits `continue` **without advancing `pos`**, so it re-reads the same character forever — an infinite loop that also spams the warning log. Separately, a malformed record makes `pattern.match(...)` return `None`, crashing on `match.end()` with `AttributeError`.

### Fix
Handle both cases: if the ident is unknown or the record doesn't match, log once and resync to the next NUL-terminated entry (`stdout.find("\x00", pos) + 1`), or end the loop if no NUL remains. This is a defensive guard — a single unexpected entry can no longer wedge the status parser.

---
*Prepared with Claude Fable 5 (Low effort mode).*
