### PR TITLE
Write patches as UTF-8 with LF line endings

### DIFF
--- a/gitfourchette/diffview/diffview.py
+++ b/gitfourchette/diffview/diffview.py
@@ -320,7 +320,7 @@ class DiffView(CodeView):
             return
 
         def dump(path: str):
-            Path(path).write_text(patchData, encoding="utf-8")
+            Path(path).write_text(patchData, encoding="utf-8", newline="\n")
 
         name = os.path.basename(self.currentLocator.path) + "[partial].patch"
         qfd = PersistentFileDialog.saveFile(self, "SaveFile", _("Export selected lines"), name)

--- a/gitfourchette/tasks/exporttasks.py
+++ b/gitfourchette/tasks/exporttasks.py
@@ -25,7 +25,10 @@ def savePatch(task: RepoTask, patch: str, fileName="") -> str:
     savePath = yield from task.flowFileDialog(qfd)
 
     yield from task.flowEnterWorkerThread()
-    Path(savePath).write_text(patch)
+    # Write patches verbatim: force UTF-8 (not the locale encoding, which fails
+    # on non-cp1252 content on Windows) and keep LF line endings (CRLF
+    # translation corrupts --binary base85 payloads and can break git apply).
+    Path(savePath).write_text(patch, encoding="utf-8", newline="\n")
 
     if task.repo.is_in_workdir(savePath):
         task.epilog.effects |= TaskEffects.Workdir  # invalidate workdir if saved file to it

--- a/gitfourchette/trash.py
+++ b/gitfourchette/trash.py
@@ -143,7 +143,7 @@ class Trash:
 
     def backupPatch(self, workdir: str, text: str, originalPath: str = "") -> Path:
         trashFile = self.newFile(workdir, ext=".patch", originalPath=originalPath)
-        trashFile.write_text(text, encoding="utf-8")
+        trashFile.write_text(text, encoding="utf-8", newline="\n")
         return trashFile
 
     def backupTree(self, workdir: str, treePath: str) -> Path:


### PR DESCRIPTION
### Problem
Patch files are written with `Path.write_text(...)` without an explicit `encoding` or `newline`:

- **Encoding:** defaults to the locale encoding (`cp1252` on Windows), so exporting any patch containing non-cp1252 characters raises `UnicodeEncodeError` inside the worker thread and the export fails.
- **Newlines:** default text mode translates `\n` → `\r\n` on Windows. `GitDriver.buildDiffCommand` always passes `--binary`, and CRLF corrupts the base85 binary payloads; it can also break `git apply` on the re-saved trash copies of discarded patches.

### Fix
Pin `encoding="utf-8", newline="\n"` at the three patch write sites:
- `tasks/exporttasks.py` (`savePatch`)
- `diffview/diffview.py` (`exportPatch` — partial-line export)
- `trash.py` (`backupPatch` — trash backup of discarded patches)

---
*Prepared with Claude Fable 5 (Low effort mode).*
