### PR TITLE
fix(cherrypick): report Git's error instead of NotImplementedError

### DIFF
--- a/gitfourchette/tasks/committasks.py
+++ b/gitfourchette/tasks/committasks.py
@@ -528,7 +528,9 @@ class CherrypickCommit(RepoTask):
         exitCode = driver.exitCode()
         logger.debug(f"cherry-pick rc={exitCode}")
         if exitCode not in [0, 1]:
-            raise NotImplementedError(f"'git cherry-pick' exit code {exitCode}")
+            # Surface Git's own error message instead of an opaque exception
+            # (e.g. exit code 128 when local changes would be overwritten).
+            raise AbortTask(driver.htmlErrorText(), details=driver.formatCommandLine())
 
         yield from self.flowEnterWorkerThread()
 

--- a/test/test_tasks_commit.py
+++ b/test/test_tasks_commit.py
@@ -706,6 +706,29 @@ def testCherrypickDud(tempDir, mainWindow):
     assert rw.repo.state() == RepositoryState.NONE
 
 
+def testCherrypickGitError(tempDir, mainWindow):
+    """Cherry-pick failing with an unexpected exit code must report Git's own
+    error message instead of raising an opaque NotImplementedError."""
+    wd = unpackRepo(tempDir)
+
+    with RepoContext(wd) as repo:
+        repo.checkout_local_branch("no-parent")
+
+    # Dirty a file that the cherry-pick would overwrite: git bails out with rc 128.
+    writeFile(f"{wd}/a/a1.txt", "local uncommitted changes\n")
+
+    oid = Oid(hex='ac7e7e44c1885efb472ad54a78327d66bfc4ecef')  # "First a/a1"
+
+    rw = mainWindow.openRepo(wd)
+    rw.jump(NavLocator.inCommit(oid))
+    triggerContextMenuAction(rw.graphView.viewport(), "cherry")
+    acceptQMessageBox(rw, "do you want to apply.+changes from.+ac7e7e4")
+
+    qmb = findQMessageBox(rw, "would be overwritten")
+    qmb.accept()
+    assert rw.repo.state() == RepositoryState.NONE
+
+
 def testAbortCherrypick(tempDir, mainWindow):
     wd = unpackRepo(tempDir)
 


### PR DESCRIPTION
Closes #129

`CherrypickCommit` raised a bare `NotImplementedError` for any `git cherry-pick` exit code other than 0 or 1, so a genuine Git failure (rc 128 when local changes would be overwritten) showed up as an opaque traceback instead of the message Git actually printed. It now raises `AbortTask(driver.htmlErrorText())`, matching how `PullBranch` and `ApplyStash` already report Git failures.

New `testCherrypickGitError` dirties the file the cherry-pick would overwrite; it fails on master and passes with the fix.
